### PR TITLE
Check for and return null for non-planar and/or open curves

### DIFF
--- a/Clipper_Engine/Clipper_Engine.csproj
+++ b/Clipper_Engine/Clipper_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -35,6 +35,9 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BHoM_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
     </Reference>
     <Reference Include="clipper_library, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Clipper.6.4.0\lib\net40\clipper_library.dll</HintPath>

--- a/Clipper_Engine/Compute/Offset.cs
+++ b/Clipper_Engine/Compute/Offset.cs
@@ -35,13 +35,30 @@ namespace BH.Engine.Geometry.Offset
         /****      public Methods                       ****/
         /***************************************************/
 
-        [Description("Offset a curve by the given distance (using Clipper http://www.angusj.com/delphi/clipper.php)")]
+        [PreviousVersion("5.3", "BH.Engine.Geometry.Offset.Compute.Offset(BH.oM.Geometry.Polyline, System.Double)")]
+        [Description("Offset a curve by the given distance (using Clipper http://www.angusj.com/delphi/clipper.php). Method only works for closed, planar polylines.")]
         [Input("polyline", "A BHoM Polyline representing the curve to offset")]
         [Input("distance", "The distance by which to offset the curve (-Ve is inwards)")]
+        [Input("tolerance", "Tolerance to be used for planarity and closedness checks.")]
         [Output("polylines", "A list of BHoM Polylines")]
-        public static List<Polyline> Offset(this Polyline polyline, double distance = 0)
+        public static List<Polyline> Offset(this Polyline polyline, double distance = 0, double tolerance = Tolerance.Distance)
         {
+            if (polyline == null)
+                return null;
+
             if (distance == 0) { return new List<Polyline> { polyline }; }
+
+            if (!polyline.IsClosed(tolerance))
+            {
+                Base.Compute.RecordError("Clipper Offset method only works for closed polylines (polygons).");
+                return null;
+            }
+
+            if (!polyline.IsPlanar(tolerance))
+            {
+                Base.Compute.RecordError("Clipper Offset method only works for planar polylines.");
+                return null;
+            }
 
             // Transform Polyline to XY plane at Z = 0
             Vector zVector = BH.Engine.Geometry.Create.Vector(0, 0, 1);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #43

<!-- Add short description of what has been fixed -->

Checks that the input curve is closed and/or planar, and returns null if found, as method was returning non-sensical results for those cases.

Adding tolerance input with default value to allow to control the checks for closedness as well as planarity.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->